### PR TITLE
Left-slide navigation menu component

### DIFF
--- a/src/assets/images/icons/icons.ts
+++ b/src/assets/images/icons/icons.ts
@@ -1,0 +1,5 @@
+export const icons: {[name:string]: string} = {
+    door: require('./door.png'),
+    green: require('./green.png'),
+    map: require('./map.png')
+}

--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -1,14 +1,40 @@
 import React, {useState} from 'react';
-import {Circle, Layer, Stage, Text} from "react-konva";
+import {Circle, Layer, Stage, Text, Image} from "react-konva";
 import CanvasGrid from "./CanvasGrid";
 import {observer} from "mobx-react-lite";
 import CanvasStore from "../stores/CanvasStore";
+import LeftSlideMenu from "./LeftSlideMenu";
+import {Grid} from "@mui/material";
+import useImage from "use-image";
+// @ts-ignore
+//import door from './test_img.png'
+
+type ImageType = {
+    src: string,
+    x: number,
+    y: number
+    key: number
+}
+const URLImage = (image: ImageType) => {
+    const [img] = useImage(image.src);
+    //console.log(img)
+    return <Image image={img} x={image.x} y={image.y} draggable={true} key={image.key}/>;
+};
+
 
 const Canvas = observer(() => {
     /**States for test to show coordinates of mouse*/
     const [curX, setCurX] = useState(0);
     const [curY, setCurY] = useState(0);
+    //let flag = 0;
+    const [flag, setFlag] = useState(0)
+    const dragUrl = React.useRef();
+    const stageRef = React.useRef(null);
 
+    const changeFlag = () =>{
+       // console.log(flag);
+        flag === 0 ? setFlag(1) : setFlag(0);
+    };
     /**Function to zoom via mouse wheel */
     /*TODO: any should be replaced with explicit type */
     const handleWheelZoom =  (e: any) => {
@@ -44,37 +70,57 @@ const Canvas = observer(() => {
         setCurX(stage.getPointerPosition().x);
         setCurY(stage.getPointerPosition().y);
     }
+    // @ts-ignore
+    // @ts-ignore
     return (
         <div>
             {/*Test Text that shows coordinates of mouse */}
             <Text>{curX}, {curY}, {CanvasStore.canvasScale}</Text>
-            <Stage
-                width={window.innerWidth}
-                height={window.innerHeight}
-                draggable
-                onWheel={handleWheelZoom}
-                scaleX={CanvasStore.canvasScale}
-                scaleY={CanvasStore.canvasScale}
-                x={CanvasStore.canvasPosition.x}
-                y={CanvasStore.canvasPosition.y}
-                onMouseMove={handleMouseMove}
-                /*TODO: any should be replaced with explicit type */
-                onDragEnd={(e: any) => {
-                    CanvasStore.canvasPosition = e.currentTarget.position();
-                }}
+            <button onClick={changeFlag}/>
+            <Grid
+                container
+                justifyContent="flex-start"
             >
-                <Layer>
-                    <CanvasGrid />
-                    {/*Test Circle*/}
-                    <Circle x={100}
-                            y={100}
-                            radius={50}
-                            fill={'red'}
-                            draggable={true}
-                            key={228}
-                    />
-                </Layer>
-            </Stage>
+                <Grid item>
+                    <LeftSlideMenu/>
+                </Grid>
+                <Grid item>
+                    <div
+                        onDrop={e =>{
+                            // @ts-ignore
+                            stageRef.current.setPointersPositions(e);
+                            // @ts-ignore
+                            CanvasStore.addImage({src: "https://konvajs.org/assets/lion.png", x: stageRef.current.getPointerPosition().x,  y: stageRef.current.getPointerPosition().y,})
+
+                        }}
+                        onDragOver={e => e.preventDefault()}
+                    >
+                        <Stage
+                            ref={stageRef}
+                            width={window.innerWidth}
+                            height={window.innerHeight}
+                            draggable
+                            onWheel={handleWheelZoom}
+                            scaleX={CanvasStore.canvasScale}
+                            scaleY={CanvasStore.canvasScale}
+                            x={CanvasStore.canvasPosition.x}
+                            y={CanvasStore.canvasPosition.y}
+                            onMouseMove={handleMouseMove}
+                            /*TODO: any should be replaced with explicit type */
+                            onDragEnd={(e: any) => {CanvasStore.canvasPosition = e.currentTarget.position();}}
+                        >
+                            <Layer>
+                                <CanvasGrid />
+                                {CanvasStore.images.map(image =>{
+                                    return <URLImage src={require("../assets/images/icons/green.png")} x={image.x} y={image.y} key={image.key ? image.key : 0}/>;
+                                })}
+                            </Layer>
+                        </Stage>
+                    </div>
+                </Grid>
+            </Grid>
+
+
         </div>
     );
 })

--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -1,40 +1,20 @@
 import React, {useState} from 'react';
-import {Circle, Layer, Stage, Text, Image} from "react-konva";
+import {Circle, Layer, Stage, Text, Image, KonvaNodeComponent} from "react-konva";
 import CanvasGrid from "./CanvasGrid";
 import {observer} from "mobx-react-lite";
 import CanvasStore from "../stores/CanvasStore";
 import LeftSlideMenu from "./LeftSlideMenu";
 import {Grid} from "@mui/material";
-import useImage from "use-image";
-// @ts-ignore
-//import door from './test_img.png'
-
-type ImageType = {
-    src: string,
-    x: number,
-    y: number
-    key: number
-}
-const URLImage = (image: ImageType) => {
-    const [img] = useImage(image.src);
-    //console.log(img)
-    return <Image image={img} x={image.x} y={image.y} draggable={true} key={image.key}/>;
-};
+import CanvasItems from "./CanvasItems";
 
 
 const Canvas = observer(() => {
     /**States for test to show coordinates of mouse*/
     const [curX, setCurX] = useState(0);
     const [curY, setCurY] = useState(0);
-    //let flag = 0;
-    const [flag, setFlag] = useState(0)
-    const dragUrl = React.useRef();
+
     const stageRef = React.useRef(null);
 
-    const changeFlag = () =>{
-       // console.log(flag);
-        flag === 0 ? setFlag(1) : setFlag(0);
-    };
     /**Function to zoom via mouse wheel */
     /*TODO: any should be replaced with explicit type */
     const handleWheelZoom =  (e: any) => {
@@ -45,7 +25,7 @@ const Canvas = observer(() => {
         const oldScale = stage.scaleX();
         /**
          * stage.x() - absolute coordinates of stage
-         * stage.getPointerPosition().x - relative coordinates of mouse
+         * stage.getPointerPosition().x - absolute coordinates of mouse
          * */
         const mousePointTo = {
             x: stage.getPointerPosition().x / oldScale - stage.x() / oldScale,
@@ -70,13 +50,10 @@ const Canvas = observer(() => {
         setCurX(stage.getPointerPosition().x);
         setCurY(stage.getPointerPosition().y);
     }
-    // @ts-ignore
-    // @ts-ignore
     return (
         <div>
             {/*Test Text that shows coordinates of mouse */}
             <Text>{curX}, {curY}, {CanvasStore.canvasScale}</Text>
-            <button onClick={changeFlag}/>
             <Grid
                 container
                 justifyContent="flex-start"
@@ -85,13 +62,14 @@ const Canvas = observer(() => {
                     <LeftSlideMenu/>
                 </Grid>
                 <Grid item>
-                    <div
+                    <div id="canvas"
                         onDrop={e =>{
+                            e.preventDefault();
+                            /*TODO: remove ignore */
                             // @ts-ignore
                             stageRef.current.setPointersPositions(e);
                             // @ts-ignore
-                            CanvasStore.addImage({src: "https://konvajs.org/assets/lion.png", x: stageRef.current.getPointerPosition().x,  y: stageRef.current.getPointerPosition().y,})
-
+                            CanvasStore.addItem({ x: stageRef.current.getRelativePointerPosition().x,  y: stageRef.current.getRelativePointerPosition().y,})
                         }}
                         onDragOver={e => e.preventDefault()}
                     >
@@ -110,17 +88,15 @@ const Canvas = observer(() => {
                             onDragEnd={(e: any) => {CanvasStore.canvasPosition = e.currentTarget.position();}}
                         >
                             <Layer>
-                                <CanvasGrid />
-                                {CanvasStore.images.map(image =>{
-                                    return <URLImage src={require("../assets/images/icons/green.png")} x={image.x} y={image.y} key={image.key ? image.key : 0}/>;
-                                })}
+                                <CanvasGrid/>
+                            </Layer>
+                            <Layer>
+                                <CanvasItems/>
                             </Layer>
                         </Stage>
                     </div>
                 </Grid>
             </Grid>
-
-
         </div>
     );
 })

--- a/src/components/CanvasItems.tsx
+++ b/src/components/CanvasItems.tsx
@@ -4,21 +4,26 @@ import CanvasStore from "../stores/CanvasStore";
 import {icons} from "../assets/images/icons/icons";
 import useImage from "use-image";
 import {observer} from "mobx-react-lite";
-type ImageType = {
-    src: string,
-    x: number,
-    y: number
-    key: number
-}
+import {ItemType} from "../types/ItemType";
+
 const CanvasItems = observer( () => {
-    const URLImage = (image: ImageType) => {
-        const [img] = useImage(image.src);
-        return <Image image={img} x={image.x} y={image.y} draggable={true} key={image.key}/>;
+
+    const URLImage = (item: ItemType) => {
+        const [image] = useImage(item.src);
+        return <Image image={image}
+                      x={item.x}
+                      y={item.y}
+                      draggable={true}
+                      key={item._key}
+                      onDragEnd={(evt) =>
+                          CanvasStore.dragItem(item._key, evt.target.x(),  evt.target.y())
+        }/>;
+
     }
     return (
         <Group>
             {CanvasStore.images.map(image =>{
-                return <URLImage src={icons[image.src]} x={image.x} y={image.y} key={image.key ? image.key : 0}/>;
+                return <URLImage src={icons[image.src]} x={image.x} y={image.y} _key={image._key}/>;
             })}
         </Group>
 

--- a/src/components/CanvasItems.tsx
+++ b/src/components/CanvasItems.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import {Group, Image, Layer} from "react-konva";
+import CanvasStore from "../stores/CanvasStore";
+import {icons} from "../assets/images/icons/icons";
+import useImage from "use-image";
+import {observer} from "mobx-react-lite";
+type ImageType = {
+    src: string,
+    x: number,
+    y: number
+    key: number
+}
+const CanvasItems = observer( () => {
+    const URLImage = (image: ImageType) => {
+        const [img] = useImage(image.src);
+        return <Image image={img} x={image.x} y={image.y} draggable={true} key={image.key}/>;
+    }
+    return (
+        <Group>
+            {CanvasStore.images.map(image =>{
+                return <URLImage src={icons[image.src]} x={image.x} y={image.y} key={image.key ? image.key : 0}/>;
+            })}
+        </Group>
+
+    )
+})
+
+export default CanvasItems;

--- a/src/components/LeftSlideMenu.tsx
+++ b/src/components/LeftSlideMenu.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useState} from 'react';
 import {Group, Rect} from "react-konva";
 import CanvasStore from "../stores/CanvasStore";
 import {observer} from "mobx-react-lite";
@@ -6,6 +6,7 @@ import {icons} from "../assets/images/icons/icons";
 
 
 const LeftSlideMenu = observer (() => {
+    const [isOpen, setMenuState] = useState<boolean>(true)
     return (
         <div
             style={{
@@ -20,7 +21,16 @@ const LeftSlideMenu = observer (() => {
                 zIndex: 100
             }}
         >
-            {
+            <button
+                name={'Menu'}
+                onClick={() => setMenuState(!isOpen)}
+                style={{
+                    border: "1px solid black",
+                    width: "100px",
+                    height: "40px"
+                }}
+            > {'Меню с предметами'}</button>
+            {isOpen &&
                 Object.entries(icons).map(([name, src]) =>{
                     return(<img
                         style={{

--- a/src/components/LeftSlideMenu.tsx
+++ b/src/components/LeftSlideMenu.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import {Group, Rect} from "react-konva";
+import CanvasStore from "../stores/CanvasStore";
+
+
+const LeftSlideMenu = () => {
+    return (
+        <div
+            style={{
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                justifyContent: "center",
+                border: "1px solid black",
+                width: "fit-content",
+                margin: 0,
+                position: "absolute",
+                zIndex: 100
+            }}
+        >
+            <img
+                alt="lion"
+                src="https://konvajs.org/assets/lion.png"
+                draggable="true"
+                onDragStart={e =>{
+                    CanvasStore.chosenImage = require("../assets/images/icons/green.png");
+                }}
+            />
+        </div>
+    )
+};
+
+export default LeftSlideMenu;
+

--- a/src/components/LeftSlideMenu.tsx
+++ b/src/components/LeftSlideMenu.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import {Group, Rect} from "react-konva";
 import CanvasStore from "../stores/CanvasStore";
+import {observer} from "mobx-react-lite";
+import {icons} from "../assets/images/icons/icons";
 
 
-const LeftSlideMenu = () => {
+const LeftSlideMenu = observer (() => {
     return (
         <div
             style={{
@@ -18,17 +20,23 @@ const LeftSlideMenu = () => {
                 zIndex: 100
             }}
         >
-            <img
-                alt="lion"
-                src="https://konvajs.org/assets/lion.png"
-                draggable="true"
-                onDragStart={e =>{
-                    CanvasStore.chosenImage = require("../assets/images/icons/green.png");
-                }}
-            />
+            {
+                Object.entries(icons).map(([name, src]) =>{
+                    return(<img
+                        style={{
+                            maxBlockSize: 50,
+                        }}
+                        alt={name}
+                        src={src}
+                        draggable="true"
+                        onDragStart={e =>{
+                            CanvasStore.chosenImage = name;
+                        }}
+                    />)
+            })}
         </div>
     )
-};
+})
 
 export default LeftSlideMenu;
 

--- a/src/stores/CanvasStore.ts
+++ b/src/stores/CanvasStore.ts
@@ -3,11 +3,28 @@ type Point = {
     x: number,
     y: number
 }
+type Image = {
+    src: string,
+    x: number,
+    y: number,
+    key?: number
+}
+
 class CanvasStore{
     private absolutePosition : Point = {x: 0, y: 0};
     private scale: number = 1.0;
+    private itemsArray: Image[] = [];
+    private key = 1;
+    chosenImage : string | null = null;
     constructor() {
         makeAutoObservable(this)
+    }
+    addItem(item: Image){
+        item.key = ++this.key
+        this.itemsArray.push(item)
+    }
+    get images(){
+        return this.itemsArray
     }
     set canvasScale(scale: number){
         this.scale = scale

--- a/src/stores/CanvasStore.ts
+++ b/src/stores/CanvasStore.ts
@@ -1,42 +1,56 @@
 import {makeAutoObservable} from "mobx";
-type Point = {
-    x: number,
-    y: number
-}
-type Image = {
-    src: string,
-    x: number,
-    y: number,
-    key?: number
-}
+import {ItemType} from "../types/ItemType";
+import {PointType} from "../types/PointType";
+
 
 class CanvasStore{
-    private absolutePosition : Point = {x: 0, y: 0};
+    private absolutePosition : PointType = {x: 0, y: 0};
     private scale: number = 1.0;
-    private itemsArray: Image[] = [];
+    private itemsArray: ItemType[] = [];
+    /*TODO: maybe make global keys for props to ensure their uniqueness*/
     private key = 1;
     chosenImage : string | null = null;
+
     constructor() {
-        makeAutoObservable(this)
+        makeAutoObservable(this);
     }
-    addItem(item: Image){
-        item.key = ++this.key
-        this.itemsArray.push(item)
+
+    addItem(coordinates: PointType){
+        if(this.chosenImage == null){
+            return;
+        }
+        const item : ItemType ={
+            src: this.chosenImage,
+            _key: ++this.key,
+            x: coordinates.x,
+            y: coordinates.y,
+        }
+        this.itemsArray.push(item);
     }
+
+    dragItem(key: number, x: number, y: number): void{
+        const index = this.itemsArray.findIndex(item => item._key === key)
+        if(index == undefined){
+            return;
+        }
+        this.itemsArray[index].x = x;
+        this.itemsArray[index].y = y;
+    }
+
     get images(){
-        return this.itemsArray
+        return this.itemsArray;
     }
     set canvasScale(scale: number){
-        this.scale = scale
+        this.scale = scale;
     }
     get canvasScale(){
-        return this.scale
+        return this.scale;
     }
-    set canvasPosition(point: Point){
-        this.absolutePosition = point
+    set canvasPosition(point: PointType){
+        this.absolutePosition = point;
     }
     get canvasPosition(){
-        return this.absolutePosition
+        return this.absolutePosition;
     }
 }
-export default new CanvasStore()
+export default new CanvasStore();

--- a/src/types/ItemType.ts
+++ b/src/types/ItemType.ts
@@ -1,0 +1,6 @@
+export type ItemType = {
+    src: string,
+    x: number,
+    y: number
+    _key: number
+}

--- a/src/types/PointType.ts
+++ b/src/types/PointType.ts
@@ -1,0 +1,4 @@
+export type PointType = {
+    x: number,
+    y: number
+}


### PR DESCRIPTION
Simple left-slide menu with drag and drop:
- add ```assets/images/icons/icons.ts``` file with object, where all icons are declared
- add ```LeftSlideMenu``` component
- add ```CanvasItems``` component ro render all canvas items

Note:
- ```LeftSlideMenu``` should be stylized in another issue
- Should optimize items rendering. Now Items fliker when drag and drop

Closes: #5 
