### PR TITLE
Context menu for items in canvas

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,29 @@
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import Canvas from "./components/Canvas/Canvas";
 import RightSlideMenu from "./components/RightSlideMenu/RightSlideMenu";
 import NavBar from "./components/NavBar/NavBar";
+import CanvasContextMenu from "./components/Canvas/context_menu/CanvasContextMenu";
 
 
 
 const App: React.FC =() => {
+    let contextMenu = document.querySelector('#canvas__context-menu') as HTMLElement;
+    /*TODO: this is very bad, find how to always get not null but contextMenu*/
+    while(!contextMenu) {
+        contextMenu = document.querySelector('#canvas__context-menu') as HTMLElement;
+    }
+    const hideCanvasContextMenu = () => {
+        if(!contextMenu) return;
+        contextMenu.style.display = 'none';
+    }
     return (
-        <div className="App">
+        <div className="App"
+             onClick={(e) => hideCanvasContextMenu()}
+             onDragStart={(e) => hideCanvasContextMenu()}
+        >
             <NavBar/>
             <Canvas/>
+            <CanvasContextMenu/>
             <RightSlideMenu/>
         </div>
     );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,18 +3,15 @@ import Canvas from "./components/Canvas/Canvas";
 import RightSlideMenu from "./components/RightSlideMenu/RightSlideMenu";
 import NavBar from "./components/NavBar/NavBar";
 import CanvasContextMenu from "./components/Canvas/context_menu/CanvasContextMenu";
+import CanvasStore from "./stores/CanvasStore";
 
 
 
 const App: React.FC =() => {
-    let contextMenu = document.querySelector('#canvas__context-menu') as HTMLElement;
-    /*TODO: this is very bad, find how to always get not null but contextMenu*/
-    while(!contextMenu) {
-        contextMenu = document.querySelector('#canvas__context-menu') as HTMLElement;
-    }
+    useEffect(() =>{CanvasStore.contextMenu = document.querySelector('#canvas__context-menu') as HTMLElement;})
     const hideCanvasContextMenu = () => {
-        if(!contextMenu) return;
-        contextMenu.style.display = 'none';
+        if(!CanvasStore.contextMenu) return;
+        CanvasStore.contextMenu.style.display = 'none';
     }
     return (
         <div className="App"

--- a/src/components/Canvas/CanvasItems.tsx
+++ b/src/components/Canvas/CanvasItems.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useRef} from 'react';
 import {Group, Image, Layer} from "react-konva";
 import CanvasStore from "../../stores/CanvasStore";
 import {icons} from "../../assets/images/icons/icons";
@@ -9,7 +9,6 @@ import Konva from "konva";
 import KonvaEventObject = Konva.KonvaEventObject;
 
 const CanvasItems = observer( () => {
-
     const handleOnClick = (item: ItemType) => {
         console.log(item);
         CanvasStore.chosenItem = item;
@@ -40,14 +39,18 @@ const CanvasItems = observer( () => {
         CanvasStore.contextMenu.style.left = containerRect.left + stage.getPointerPosition()!.x + 4 + 'px';
     }
 
+
     const URLImage = (item: ItemType) => {
         if(!item.pictureLink){
             /*TODO include default picture*/
             item.pictureLink = icons['red'];
         }
         const [image] = useImage(item.pictureLink);
+
+
         return <Image
                 image={image}
+                //ref={(node) => CanvasStore.ref = node}
                 x={item.polygon.point.x}
                 y={item.polygon.point.y}
                 size={{width: 50, height:50}}
@@ -60,7 +63,7 @@ const CanvasItems = observer( () => {
                     CanvasStore.dragItem(item, newPoint);
                 }}
                 onContextMenu={(e) => handleContextMenu(e)}
-                onClick={(e) => handleOnClick(item)}
+                onClick={(e) => { CanvasStore.currentItemRef = e.target; handleOnClick(item);}}
         />;
 
     }

--- a/src/components/Canvas/CanvasItems.tsx
+++ b/src/components/Canvas/CanvasItems.tsx
@@ -5,17 +5,42 @@ import {icons} from "../../assets/images/icons/icons";
 import useImage from "use-image";
 import {observer} from "mobx-react-lite";
 import {ItemType} from "../../openapi";
+import Konva from "konva";
+import KonvaEventObject = Konva.KonvaEventObject;
 
 const CanvasItems = observer( () => {
 
-    const handlePointerCursor= (e:any) => {
-        const container = e.target.getStage().container();
+    const contextMenu = document.getElementById('canvas__context-menu');
+
+    const handleOnClick = (item: ItemType) => {
+        console.log(item);
+        CanvasStore.chosenItem = item;
+    }
+
+    const handlePointerCursor= (e: KonvaEventObject<MouseEvent>) => {
+        if(!e) return;
+        const container = e!.target!.getStage()!.container();
         container.style.cursor = "pointer";
     }
 
-    const handleDefaultCursor= (e:any) => {
-        const container = e.target.getStage().container();
+    const handleDefaultCursor= (e: KonvaEventObject<MouseEvent>) => {
+        if(!e) return;
+        const container = e!.target!.getStage()!.container();
         container.style.cursor = "default";
+    }
+
+    const handleContextMenu = (e : KonvaEventObject<PointerEvent>) =>{
+        if(!e) return;
+        e.evt.preventDefault();
+        if(!contextMenu) return;
+        const stage = e.target.getStage();
+        if(!stage) return;
+        const containerRect = stage.container().getBoundingClientRect();
+        if(!containerRect) return;
+        console.log(contextMenu);
+        contextMenu.style.display = 'initial';
+        contextMenu.style.top = containerRect.top + stage.getPointerPosition()!.y + 4 + 'px';
+        contextMenu.style.left = containerRect.left + stage.getPointerPosition()!.x + 4 + 'px';
     }
 
     const URLImage = (item: ItemType) => {
@@ -31,13 +56,15 @@ const CanvasItems = observer( () => {
                 size={{width: 50, height:50}}
                 draggable={true}
                 key={item.itemType_id}
-                onMouseEnter={e => handlePointerCursor(e)}
+                onMouseEnter={(e) => handlePointerCursor(e)}
                 onMouseLeave={e => handleDefaultCursor(e)}
                 onDragEnd={(event) => {
                     const newPoint = {x: event.target.x(), y: event.target.y()}
                     CanvasStore.dragItem(item, newPoint);
-                }
-        }/>;
+                }}
+                onContextMenu={(e) => handleContextMenu(e)}
+                onClick={(e) => handleOnClick(item)}
+        />;
 
     }
     return (

--- a/src/components/Canvas/CanvasItems.tsx
+++ b/src/components/Canvas/CanvasItems.tsx
@@ -10,8 +10,6 @@ import KonvaEventObject = Konva.KonvaEventObject;
 
 const CanvasItems = observer( () => {
 
-    const contextMenu = document.getElementById('canvas__context-menu');
-
     const handleOnClick = (item: ItemType) => {
         console.log(item);
         CanvasStore.chosenItem = item;
@@ -32,15 +30,14 @@ const CanvasItems = observer( () => {
     const handleContextMenu = (e : KonvaEventObject<PointerEvent>) =>{
         if(!e) return;
         e.evt.preventDefault();
-        if(!contextMenu) return;
+        if(!CanvasStore.contextMenu) return;
         const stage = e.target.getStage();
         if(!stage) return;
         const containerRect = stage.container().getBoundingClientRect();
         if(!containerRect) return;
-        console.log(contextMenu);
-        contextMenu.style.display = 'initial';
-        contextMenu.style.top = containerRect.top + stage.getPointerPosition()!.y + 4 + 'px';
-        contextMenu.style.left = containerRect.left + stage.getPointerPosition()!.x + 4 + 'px';
+        CanvasStore.contextMenu.style.display = 'initial';
+        CanvasStore.contextMenu.style.top = containerRect.top + stage.getPointerPosition()!.y + 4 + 'px';
+        CanvasStore.contextMenu.style.left = containerRect.left + stage.getPointerPosition()!.x + 4 + 'px';
     }
 
     const URLImage = (item: ItemType) => {
@@ -71,7 +68,8 @@ const CanvasItems = observer( () => {
         <Group>
             {CanvasStore.images.map(image =>{
                 if(image.pictureLink )
-                    return <URLImage pictureLink={icons[image.pictureLink]} polygon={image.polygon} itemType_id={image.itemType_id} itemName={image.itemName} valuablePlacement={''}/>;
+                   // return <URLImage pictureLink={icons[image.pictureLink]} polygon={image.polygon} itemType_id={image.itemType_id} itemName={image.itemName} valuablePlacement={''}/>;
+                    return <URLImage pictureLink={image.pictureLink} polygon={image.polygon} itemType_id={image.itemType_id} itemName={image.itemName} valuablePlacement={''}/>;
             })}
         </Group>
 

--- a/src/components/Canvas/context_menu/CanvasContextMenu.css
+++ b/src/components/Canvas/context_menu/CanvasContextMenu.css
@@ -1,0 +1,20 @@
+#canvas__context-menu{
+    display: none;
+    position: absolute;
+    width: 100px;
+    height: 100px;
+    background-color: white;
+    box-shadow: 0 0 5px grey;
+    border-radius: 3px;
+}
+#canvas__context-menu button {
+    width: 100%;
+    background-color: white;
+    border: none;
+    margin: 0;
+    padding: 10px;
+}
+
+#canvas__context-menu button:hover {
+    background-color: lightgray;
+}

--- a/src/components/Canvas/context_menu/CanvasContextMenu.tsx
+++ b/src/components/Canvas/context_menu/CanvasContextMenu.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import './CanvasContextMenu.css'
+import CanvasStore from "../../../stores/CanvasStore";
+const CanvasContextMenu = () => {
+    const contextMenu = document.getElementById('canvas__context-menu');
+    const handleDelete = () => {
+        if(!CanvasStore.chosenItem) return;
+        //CanvasStore.deleteItem(CanvasStore.chosenItem);
+        if(!contextMenu) return;
+        contextMenu.style.display = 'none';
+    }
+    return (
+        <div id="canvas__context-menu">
+            <div>
+                <button id="canvas__context-menu__button_delete"
+                        onClick={(e) => handleDelete()}
+                    >Delete</button>
+
+                <button id="canvas__context-menu__button_bring-to-front">
+
+                    Bring to front</button>
+                <button id="canvas__context-menu__button_send-to-back">Send to back</button>
+            </div>
+        </div>
+    );
+};
+
+export default CanvasContextMenu;

--- a/src/components/Canvas/context_menu/CanvasContextMenu.tsx
+++ b/src/components/Canvas/context_menu/CanvasContextMenu.tsx
@@ -16,10 +16,14 @@ const CanvasContextMenu = () => {
                         onClick={(e) => handleDelete()}
                     >Delete</button>
 
-                <button id="canvas__context-menu__button_bring-to-front">
-
+                <button id="canvas__context-menu__button_bring-to-front"
+                    onClick={() => CanvasStore.bringFront()}
+                >
                     Bring to front</button>
-                <button id="canvas__context-menu__button_send-to-back">Send to back</button>
+                <button id="canvas__context-menu__button_send-to-back"
+                        onClick={() => CanvasStore.sendBack()}
+                >
+                    Send to back</button>
             </div>
         </div>
     );

--- a/src/components/Canvas/context_menu/CanvasContextMenu.tsx
+++ b/src/components/Canvas/context_menu/CanvasContextMenu.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 import './CanvasContextMenu.css'
 import CanvasStore from "../../../stores/CanvasStore";
 const CanvasContextMenu = () => {
-    const contextMenu = document.getElementById('canvas__context-menu');
+
     const handleDelete = () => {
         if(!CanvasStore.chosenItem) return;
-        //CanvasStore.deleteItem(CanvasStore.chosenItem);
-        if(!contextMenu) return;
-        contextMenu.style.display = 'none';
+        CanvasStore.deleteItem(CanvasStore.chosenItem);
+        if(!CanvasStore.contextMenu) return;
+        CanvasStore.contextMenu.style.display = 'none';
     }
     return (
         <div id="canvas__context-menu">

--- a/src/components/NavBar/NavBarIcon.tsx
+++ b/src/components/NavBar/NavBarIcon.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useState} from 'react';
 import IconButton from '@mui/material/IconButton';
 import Stack from '@mui/material/Stack';
 import DeleteIcon from '@mui/icons-material/Delete';
@@ -6,13 +6,14 @@ import UndoIcon from '@mui/icons-material/Undo';
 import RedoIcon from '@mui/icons-material/Redo';
 import SaveIcon from '@mui/icons-material/Save';
 import CanvasStore from "../../stores/CanvasStore";
+import {observer} from "mobx-react-lite";
 
 interface IconProps {
     active: any;
     setActive: any;
 }
 
-const NavBarIcon: React.FC<IconProps> = ({active, setActive}) =>{
+const NavBarIcon: React.FC<IconProps> = observer (({active, setActive})  =>{
     return (
         <Stack direction="row" spacing={1}>
             <IconButton
@@ -33,22 +34,22 @@ const NavBarIcon: React.FC<IconProps> = ({active, setActive}) =>{
             </IconButton>
             <IconButton
                 aria-label="icon"
-                onClick={() => setActive(false)}
-                disabled={active}
+                onClick={() => {setActive(false); CanvasStore.undo();}}
+                disabled={CanvasStore.undoBlocked}
                 color='inherit'
             >
-                <UndoIcon onClick={() => CanvasStore.undo()}/>
+                <UndoIcon />
             </IconButton>
             <IconButton
                 aria-label="icon"
-                onClick={() => setActive(false)}
-                disabled={active}
+                onClick={() => {setActive(false); CanvasStore.redo();}}
+                disabled={CanvasStore.redoBlocked}
                 color='inherit'
             >
-                <RedoIcon onClick={() => CanvasStore.redo()}/>
+                <RedoIcon/>
             </IconButton>
         </Stack>
     );
-};
+});
 
 export default NavBarIcon;

--- a/src/stores/CanvasStore.ts
+++ b/src/stores/CanvasStore.ts
@@ -94,7 +94,7 @@ class CanvasStore{
             return;
         }
         if(!undoRedoSkip){
-            this.undoRedoAdapter.addAction(new DragItem(item, {x: newPoint.x, y: newPoint.y}))
+            this.undoRedoAdapter.addAction(new DragItem(item, {x: newPoint.x, y: newPoint.y}));
         }
         this.itemsArray[index].polygon.point.x = newPoint.x;
         this.itemsArray[index].polygon.point.y = newPoint.y;
@@ -156,5 +156,12 @@ class CanvasStore{
     get canvasPosition(){
         return this.absolutePosition;
     }
+    public undoBlocked = true;
+    public redoBlocked = true;
+    public setUndoRedoBlocked(){
+        this.redoBlocked = this.undoRedoAdapter.getUndoRedoStatus().redoBlocked;
+        this.undoBlocked = this.undoRedoAdapter.getUndoRedoStatus().undoBlocked;
+    }
+
 }
 export default new CanvasStore();

--- a/src/stores/CanvasStore.ts
+++ b/src/stores/CanvasStore.ts
@@ -22,9 +22,10 @@ class CanvasStore{
     private key = 1;
     private wallIndex = 0;
     private floorIndex = 0;
-
+    //Chosen image when drag&drop
     chosenImage : string | null = null;
-
+    //Chosen item on context menu. Do it private?
+    chosenItem : ItemType | null = null;
     constructor() {
         makeAutoObservable(this);
     }
@@ -41,6 +42,7 @@ class CanvasStore{
         if(this.chosenImage == null){
             return;
         }
+        console.log("chosen image",this.chosenImage);
         const item : ItemType ={
             itemName: "",
             valuablePlacement: "",
@@ -74,7 +76,7 @@ class CanvasStore{
         this.itemsArray[index].polygon.point.y = newPoint.y;
         if(undoRedoSkip){
             this.itemsArray = this.itemsArray.slice()
-            }
+        }
     }
 
     deleteItem(item: ItemType, undoRedoSkip: boolean = false){

--- a/src/stores/CanvasStore.ts
+++ b/src/stores/CanvasStore.ts
@@ -7,6 +7,7 @@ import {DeleteItem} from "./undo_redo/actions/DeleteItem";
 import {AddItem} from "./undo_redo/actions/AddItem";
 import {icons} from "../assets/images/icons/icons";
 import Konva from "konva";
+import {SendItemBackFront} from "./undo_redo/actions/SendItemBackFront";
 
 
 class CanvasStore{
@@ -38,12 +39,18 @@ class CanvasStore{
 
     bringFront(){
         if(this.currentItemRef){
+            const prevZIndex = this.currentItemRef.zIndex();
             this.currentItemRef.moveToTop();
+            const nextZIndex = this.currentItemRef.zIndex();
+            this.undoRedoAdapter.addAction(new SendItemBackFront(this.currentItemRef,prevZIndex,nextZIndex));
         }
     }
     sendBack(){
         if(this.currentItemRef){
+            const prevZIndex = this.currentItemRef.zIndex();
             this.currentItemRef.moveToBottom();
+            const nextZIndex = this.currentItemRef.zIndex();
+            this.undoRedoAdapter.addAction(new SendItemBackFront(this.currentItemRef,prevZIndex,nextZIndex));
         }
     }
 

--- a/src/stores/CanvasStore.ts
+++ b/src/stores/CanvasStore.ts
@@ -5,6 +5,7 @@ import {UndoRedoAdapter} from "./undo_redo/UndoRedoAdapter";
 import {DragItem} from "./undo_redo/actions/DragItem";
 import {DeleteItem} from "./undo_redo/actions/DeleteItem";
 import {AddItem} from "./undo_redo/actions/AddItem";
+import {icons} from "../assets/images/icons/icons";
 
 
 class CanvasStore{
@@ -12,6 +13,8 @@ class CanvasStore{
     private absolutePosition : PointType = {x: 0, y: 0};
     private scale: number = 1.0;
     private itemsArray: ItemType[] = [];
+
+    public contextMenu: HTMLElement | null = null;
 
     private wallsArray: Wall[] = [];
     public isWallToolActive = false;
@@ -46,7 +49,7 @@ class CanvasStore{
         const item : ItemType ={
             itemName: "",
             valuablePlacement: "",
-            pictureLink: this.chosenImage,
+            pictureLink: icons[this.chosenImage],
             itemType_id: ++this.key,
             polygon : {
                 point:{

--- a/src/stores/CanvasStore.ts
+++ b/src/stores/CanvasStore.ts
@@ -6,13 +6,14 @@ import {DragItem} from "./undo_redo/actions/DragItem";
 import {DeleteItem} from "./undo_redo/actions/DeleteItem";
 import {AddItem} from "./undo_redo/actions/AddItem";
 import {icons} from "../assets/images/icons/icons";
+import Konva from "konva";
 
 
 class CanvasStore{
     private undoRedoAdapter = new UndoRedoAdapter();
     private absolutePosition : PointType = {x: 0, y: 0};
     private scale: number = 1.0;
-    private itemsArray: ItemType[] = [];
+    public itemsArray: ItemType[] = [];
 
     public contextMenu: HTMLElement | null = null;
 
@@ -21,6 +22,7 @@ class CanvasStore{
 
     public clickCounter = 0;
 
+    public currentItemRef:  Konva.Shape | Konva.Stage | null = null;
     /*TODO: maybe make global keys for props to ensure their uniqueness*/
     private key = 1;
     private wallIndex = 0;
@@ -29,8 +31,20 @@ class CanvasStore{
     chosenImage : string | null = null;
     //Chosen item on context menu. Do it private?
     chosenItem : ItemType | null = null;
+
     constructor() {
         makeAutoObservable(this);
+    }
+
+    bringFront(){
+        if(this.currentItemRef){
+            this.currentItemRef.moveToTop();
+        }
+    }
+    sendBack(){
+        if(this.currentItemRef){
+            this.currentItemRef.moveToBottom();
+        }
     }
 
     undo(): void{

--- a/src/stores/undo_redo/UndoRedoAdapter.ts
+++ b/src/stores/undo_redo/UndoRedoAdapter.ts
@@ -1,4 +1,5 @@
 import {Action} from "./Action";
+import CanvasStore from "../CanvasStore";
 
 export class UndoRedoAdapter {
     private history: Action[] = [];
@@ -10,6 +11,7 @@ export class UndoRedoAdapter {
         }
         this.index++;
         this.history[this.index].redo();
+        CanvasStore.setUndoRedoBlocked();
     }
     undo(): void {
         if(this.index < 0){
@@ -17,6 +19,7 @@ export class UndoRedoAdapter {
         }
         this.history[this.index].undo();
         this.index--;
+        CanvasStore.setUndoRedoBlocked();
     }
     addAction(action : Action) : void {
         if(this.index + 1 != this.history.length){
@@ -28,5 +31,17 @@ export class UndoRedoAdapter {
             this.history.shift();
         }
         this.index = this.history.length - 1;
+        CanvasStore.setUndoRedoBlocked();
+    }
+    getUndoRedoStatus() : {undoBlocked: boolean, redoBlocked: boolean} {
+        let undoBlocked: boolean = false;
+        let redoBlocked: boolean = false;
+        if(this.index === -1){
+            undoBlocked = true;
+        }
+        if(this.index === this.history.length-1){
+            redoBlocked = true;
+        }
+        return {undoBlocked: undoBlocked, redoBlocked: redoBlocked};
     }
 }

--- a/src/stores/undo_redo/UndoRedoAdapter.ts
+++ b/src/stores/undo_redo/UndoRedoAdapter.ts
@@ -13,7 +13,7 @@ export class UndoRedoAdapter {
     }
     undo(): void {
         if(this.index < 0){
-            return
+            return;
         }
         this.history[this.index].undo();
         this.index--;

--- a/src/stores/undo_redo/actions/SendItemBackFront.ts
+++ b/src/stores/undo_redo/actions/SendItemBackFront.ts
@@ -1,0 +1,22 @@
+import {Action} from "../Action";
+import Konva from "konva";
+
+export class SendItemBackFront implements Action {
+    private itemRef: Konva.Shape | Konva.Stage;
+    private prevZIndex: number;
+    private nextZIndex: number;
+    constructor(itemRef: Konva.Shape | Konva.Stage, prevZIndex: number, nextZIndex: number) {
+        this.itemRef = itemRef;
+        this.prevZIndex = prevZIndex;
+        this.nextZIndex = nextZIndex;
+    }
+
+    redo(): void {
+        this.itemRef.zIndex(this.nextZIndex);
+    }
+
+    undo(): void {
+        this.itemRef.zIndex(this.prevZIndex);
+    }
+
+}


### PR DESCRIPTION
## Add context menu for items with three buttons:
- button for deletion of item
- button for bringing an item in front
- button for sending an item back
- handle undo/redo for these actions
## Changes in code:
 - add component ```CanvasContextMenu.tsx``` for context menu
 - add hook ```useEffect``` in ```App.tsx``` to get context-menu DOM-element
 - in ```CanvasStore.ts``` fixed that items held key of link to picture, but not the actual link to picture
 - add functions ```bringFront()``` and ```sendBack()``` in ```CanvasStore.ts``` to handle change the layer of the item
 - add action ```SendItemBackFront``` for it
 closes #34 